### PR TITLE
fix: improve build flow for production-style networks

### DIFF
--- a/xbridge_cli/bridge/create_account.py
+++ b/xbridge_cli/bridge/create_account.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import click
 from xrpl import CryptoAlgorithm
-from xrpl.models import AccountInfo, ServerInfo, XChainAccountCreateCommit
+from xrpl.models import AccountInfo, XChainAccountCreateCommit
 from xrpl.utils import drops_to_xrp, xrp_to_drops
 from xrpl.wallet import Wallet
 
@@ -16,6 +16,7 @@ from xbridge_cli.utils import (
     submit_tx,
     wait_for_attestations,
 )
+from xbridge_cli.utils.misc import is_standalone_network
 
 
 @click.command(name="create-account")
@@ -126,9 +127,7 @@ def create_xchain_account(
         from_client = issuing_client
         to_client = locking_client
 
-    locking_server_info = locking_client.request(ServerInfo())
-    locking_validators = locking_server_info.result["info"]["validation_quorum"]
-    if locking_validators != 0 and close_ledgers:
+    if is_standalone_network(locking_client) and close_ledgers:
         raise XBridgeCLIException(
             "Must use `--no-close-ledgers` on a non-standalone node."
         )

--- a/xbridge_cli/bridge/create_account.py
+++ b/xbridge_cli/bridge/create_account.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import click
 from xrpl import CryptoAlgorithm
-from xrpl.models import AccountInfo, XChainAccountCreateCommit
+from xrpl.models import AccountInfo, ServerInfo, XChainAccountCreateCommit
 from xrpl.utils import drops_to_xrp, xrp_to_drops
 from xrpl.wallet import Wallet
 
@@ -125,6 +125,13 @@ def create_xchain_account(
     else:
         from_client = issuing_client
         to_client = locking_client
+
+    locking_server_info = locking_client.request(ServerInfo())
+    locking_validators = locking_server_info.result["info"]["validation_quorum"]
+    if locking_validators != 0 and close_ledgers:
+        raise XBridgeCLIException(
+            "Must use `--no-close-ledgers` on a non-standalone node."
+        )
 
     min_create_account_amount = bridge_config.create_account_amounts[
         0 if from_locking else 1

--- a/xbridge_cli/bridge/create_account.py
+++ b/xbridge_cli/bridge/create_account.py
@@ -127,7 +127,7 @@ def create_xchain_account(
         from_client = issuing_client
         to_client = locking_client
 
-    if is_standalone_network(locking_client) and close_ledgers:
+    if not is_standalone_network(locking_client) and close_ledgers:
         raise XBridgeCLIException(
             "Must use `--no-close-ledgers` on a non-standalone node."
         )

--- a/xbridge_cli/bridge/setup.py
+++ b/xbridge_cli/bridge/setup.py
@@ -16,7 +16,6 @@ from xrpl.models import (
     Currency,
     IssuedCurrency,
     Payment,
-    ServerInfo,
     ServerState,
     SignerEntry,
     SignerListSet,
@@ -35,6 +34,7 @@ from xbridge_cli.utils import (
     check_bridge_exists,
     submit_tx,
 )
+from xbridge_cli.utils.misc import is_standalone_network
 
 _GENESIS_ACCOUNT = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
 _GENESIS_SEED = "snoPBrXtMeMyMHUVTgbuqAfg1SUTb"
@@ -142,9 +142,7 @@ def setup_bridge(
     issuing_url = f"http://{issuing_endpoint['Host']}:{issuing_endpoint['JsonRPCPort']}"
     issuing_client = JsonRpcClient(issuing_url)
 
-    locking_server_info = locking_client.request(ServerInfo())
-    locking_validators = locking_server_info.result["info"]["validation_quorum"]
-    if locking_validators != 0 and close_ledgers:
+    if is_standalone_network(locking_client) and close_ledgers:
         raise XBridgeCLIException(
             "Must use `--no-close-ledgers` on a non-standalone node."
         )

--- a/xbridge_cli/bridge/setup.py
+++ b/xbridge_cli/bridge/setup.py
@@ -3,19 +3,16 @@
 import json
 import os
 from pprint import pformat
-from typing import Any, Dict, List, Literal, Optional, TypedDict, Union, cast
+from typing import List, Optional
 
 import click
 from xrpl import CryptoAlgorithm
 from xrpl.account import does_account_exist
 from xrpl.clients import JsonRpcClient
-from xrpl.core.binarycodec import encode
-from xrpl.core.keypairs import sign
 from xrpl.models import (
     XRP,
     AccountSet,
     AccountSetFlag,
-    Amount,
     Currency,
     IssuedCurrency,
     Payment,
@@ -28,7 +25,6 @@ from xrpl.models import (
     XChainBridge,
     XChainCreateBridge,
 )
-from xrpl.models.transactions.transaction import transaction_json_to_binary_codec_form
 from xrpl.wallet import Wallet
 
 from xbridge_cli.exceptions import XBridgeCLIException
@@ -43,42 +39,6 @@ from xbridge_cli.utils import (
 _GENESIS_ACCOUNT = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
 _GENESIS_SEED = "snoPBrXtMeMyMHUVTgbuqAfg1SUTb"
 _GENESIS_WALLET = Wallet(_GENESIS_SEED, 0)
-
-
-class _UnsignedAttestation(TypedDict):
-    xchain_bridge: Dict[str, Any]
-    other_chain_source: str
-    amount: Amount
-    attestation_reward_account: str
-    was_locking_chain_send: Union[Literal[0], Literal[1]]
-    xchain_account_create_count: str
-    destination: str
-    signature_reward: Amount
-
-
-class _SignedAttestation(_UnsignedAttestation):
-    public_key: str
-    signature: str
-
-
-def _sign_attestation(
-    attestation: _UnsignedAttestation,
-    wallet: Wallet,
-) -> _SignedAttestation:
-    attestation_xrpl = transaction_json_to_binary_codec_form(
-        cast(Dict[str, Any], attestation)
-    )
-    encoded_obj = encode(attestation_xrpl)
-    signature = sign(bytes.fromhex(encoded_obj), wallet.private_key)
-    signed_attestation: _SignedAttestation = cast(
-        _SignedAttestation,
-        {
-            **attestation,
-            "signature": signature,
-            "public_key": wallet.public_key,
-        },
-    )
-    return signed_attestation
 
 
 @click.command(name="build")

--- a/xbridge_cli/bridge/setup.py
+++ b/xbridge_cli/bridge/setup.py
@@ -142,7 +142,7 @@ def setup_bridge(
     issuing_url = f"http://{issuing_endpoint['Host']}:{issuing_endpoint['JsonRPCPort']}"
     issuing_client = JsonRpcClient(issuing_url)
 
-    if is_standalone_network(locking_client) and close_ledgers:
+    if not is_standalone_network(locking_client) and close_ledgers:
         raise XBridgeCLIException(
             "Must use `--no-close-ledgers` on a non-standalone node."
         )

--- a/xbridge_cli/bridge/transfer.py
+++ b/xbridge_cli/bridge/transfer.py
@@ -151,7 +151,7 @@ def send_transfer(
         dst_client = locking_client
         from_issue = bridge_obj.issuing_chain_issue
 
-    if is_standalone_network(locking_client) and close_ledgers:
+    if not is_standalone_network(locking_client) and close_ledgers:
         raise XBridgeCLIException(
             "Must use `--no-close-ledgers` on a non-standalone node."
         )

--- a/xbridge_cli/bridge/transfer.py
+++ b/xbridge_cli/bridge/transfer.py
@@ -9,6 +9,7 @@ from xrpl.models import (
     Currency,
     IssuedCurrency,
     Response,
+    ServerInfo,
     Transaction,
     Tx,
     XChainCommit,
@@ -152,6 +153,13 @@ def send_transfer(
         src_client = issuing_client
         dst_client = locking_client
         from_issue = bridge_obj.issuing_chain_issue
+
+    locking_server_info = locking_client.request(ServerInfo())
+    locking_validators = locking_server_info.result["info"]["validation_quorum"]
+    if locking_validators != 0 and close_ledgers:
+        raise XBridgeCLIException(
+            "Must use `--no-close-ledgers` on a non-standalone node."
+        )
 
     if isinstance(from_issue, IssuedCurrency):
         original_issue: Currency = from_issue

--- a/xbridge_cli/bridge/transfer.py
+++ b/xbridge_cli/bridge/transfer.py
@@ -9,7 +9,6 @@ from xrpl.models import (
     Currency,
     IssuedCurrency,
     Response,
-    ServerInfo,
     Transaction,
     Tx,
     XChainCommit,
@@ -19,6 +18,7 @@ from xrpl.wallet import Wallet
 
 from xbridge_cli.exceptions import XBridgeCLIException
 from xbridge_cli.utils import get_config, submit_tx, wait_for_attestations
+from xbridge_cli.utils.misc import is_standalone_network
 
 
 def _submit_tx(
@@ -151,9 +151,7 @@ def send_transfer(
         dst_client = locking_client
         from_issue = bridge_obj.issuing_chain_issue
 
-    locking_server_info = locking_client.request(ServerInfo())
-    locking_validators = locking_server_info.result["info"]["validation_quorum"]
-    if locking_validators != 0 and close_ledgers:
+    if is_standalone_network(locking_client) and close_ledgers:
         raise XBridgeCLIException(
             "Must use `--no-close-ledgers` on a non-standalone node."
         )

--- a/xbridge_cli/bridge/transfer.py
+++ b/xbridge_cli/bridge/transfer.py
@@ -20,9 +20,6 @@ from xrpl.wallet import Wallet
 from xbridge_cli.exceptions import XBridgeCLIException
 from xbridge_cli.utils import get_config, submit_tx, wait_for_attestations
 
-_ATTESTATION_TIME_LIMIT = 10  # in seconds
-_WAIT_STEP_LENGTH = 0.05
-
 
 def _submit_tx(
     tx: Transaction,

--- a/xbridge_cli/utils/misc.py
+++ b/xbridge_cli/utils/misc.py
@@ -2,5 +2,21 @@
 
 import click
 from xrpl import CryptoAlgorithm
+from xrpl.clients import JsonRpcClient
+from xrpl.models import ServerInfo
 
 CryptoAlgorithmChoice = click.Choice([e.value for e in CryptoAlgorithm])
+
+
+def is_standalone_network(client: JsonRpcClient) -> bool:
+    """Checks if a client is connected to a standalone network or not.
+
+    Args:
+        client (JsonRpcClient): The client connected to the network.
+
+    Returns:
+        bool: Whether the network is a standalone node.
+    """
+    server_info = client.request(ServerInfo())
+    validators = server_info.result["info"]["validation_quorum"]
+    return bool(validators == 0)


### PR DESCRIPTION
## High Level Overview of Change

This PR refactors the `bridge build` command to (for an XRP-XRP bridge) transfer the funds to create the issuing chain witness submission accounts via a `Payment` from the issuing chain's genesis account, and then transfer the same amount of funds from the funding seed to the locking chain's door account (to ensure that the amount of funds locked in the locking chain's door account is the same as the amount of funds that have been issued on the issuing chain). This avoids using the bridge for the account creation, which simplifies a lot of issues.

It also adds a check to ensure that when running on an external network, the user is using `--no-close-ledgers` (it errors otherwise).

### Context of Change

These issues occurred while setting up production-style networks.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Tests pass locally. The docker container still hasn't been fixed.
