### PR TITLE
change: switch `transfer` to expect XRP instead of drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change the `bridge build` flow to use payments instead of `XChainAccountCreateCommit`s
 - In the `bridge build` command, only submit a tx if it hasn't already been submitted
+- Accept XRP in the `bridge build` command instead of drops
 
 ### Fixed
 

--- a/scripts/docker-start.sh
+++ b/scripts/docker-start.sh
@@ -9,4 +9,4 @@ jq '.LockingChain.WitnessRewardAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.j
 xbridge-cli bridge build --name=bridge -v
 xbridge-cli fund locking_chain raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
 xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10 -v
-xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10000000 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose
+xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose

--- a/scripts/iou-start.sh
+++ b/scripts/iou-start.sh
@@ -11,7 +11,7 @@ xbridge-cli server start-all --witness-only
 xbridge-cli server list
 xbridge-cli fund locking_chain raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
 xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10 -v
-xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10000000 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose
+xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose
 
 echo "set up IOU bridge"
 xbridge-cli fund locking_chain raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -9,4 +9,4 @@ jq '.LockingChain.WitnessRewardAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.j
 xbridge-cli bridge build --name=bridge -v
 xbridge-cli fund locking_chain raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
 xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10 -v
-xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10000000 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose
+xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose

--- a/scripts/tutorial.sh
+++ b/scripts/tutorial.sh
@@ -10,4 +10,4 @@ jq '.LockingChain.WitnessRewardAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.j
 xbridge-cli bridge build --name=bridge -v
 xbridge-cli fund locking_chain raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
 xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10 -v
-xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10000000 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --tutorial
+xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --tutorial

--- a/tests/bridge/test_transfer.py
+++ b/tests/bridge/test_transfer.py
@@ -17,7 +17,8 @@ class TestBridgeTransfer:
 
         send_wallet = Wallet.create()
         receive_wallet = Wallet.create()
-        amount = xrp_to_drops(10)
+        xrp_amount = 10
+        amount = xrp_to_drops(xrp_amount)
 
         # initialize accounts
         fund_result1 = runner.invoke(
@@ -64,7 +65,7 @@ class TestBridgeTransfer:
                 "transfer",
                 "--bridge=test_bridge",
                 "--from_locking",
-                f"--amount={amount}",
+                f"--amount={xrp_amount}",
                 f"--from={send_wallet.seed}",
                 f"--to={receive_wallet.seed}",
                 "-vv",
@@ -87,7 +88,8 @@ class TestBridgeTransfer:
 
         send_wallet = Wallet.create()
         receive_wallet = Wallet.create()
-        amount = xrp_to_drops(10)
+        xrp_amount = 10
+        amount = xrp_to_drops(xrp_amount)
 
         # initialize accounts
         fund_result1 = runner.invoke(
@@ -137,7 +139,7 @@ class TestBridgeTransfer:
                 "transfer",
                 "--bridge=test_bridge",
                 "--from_locking",
-                f"--amount={amount}",
+                f"--amount={xrp_amount}",
                 f"--from={send_wallet.seed}",
                 f"--to={receive_wallet.seed}",
                 "-vv",

--- a/xbridge_cli/misc/fund.py
+++ b/xbridge_cli/misc/fund.py
@@ -21,7 +21,7 @@ from xbridge_cli.utils import get_config, submit_tx
     nargs=-1,
 )
 @click.option(
-    "--amount", type=int, default=1000, help="The amount to fund each account."
+    "--amount", type=int, default=1000, help="The amount to fund each account (in XRP)."
 )
 @click.option(
     "-v",
@@ -42,7 +42,7 @@ def fund_account(
     Args:
         chain: The chain to fund an account on.
         accounts: The account(s) to fund.
-        amount: The amount to fund each account.
+        amount: The amount to fund each account (in XRP).
         verbose: Whether or not to print more verbose information.
 
     Raises:


### PR DESCRIPTION
## High Level Overview of Change

Title says it all.

### Context of Change

`create-account` expects XRP, it makes more intuitive sense for `transfer` to also expect XRP

### Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Test Plan

Fixed tests to account for the change. Tests pass locally.
