### PR TITLE
change: adjust default verbosity for bridge commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change the `bridge build` flow to use payments instead of `XChainAccountCreateCommit`s
 - In the `bridge build` command, only submit a tx if it hasn't already been submitted
 - Accept XRP in the `bridge build` command instead of drops
+- Adjust default verbosity for bridge commands and add `--silent` flags
 
 ### Fixed
 

--- a/scripts/docker-start.sh
+++ b/scripts/docker-start.sh
@@ -6,7 +6,7 @@ xbridge-cli explorer
 jq .LockingChain.DoorAccount.Address $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
 jq '.LockingChain.WitnessSubmitAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
 jq '.LockingChain.WitnessRewardAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
-xbridge-cli bridge build --name=bridge -v
+xbridge-cli bridge build --name=bridge
 xbridge-cli fund locking_chain raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
-xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10 -v
-xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose
+xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10
+xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM

--- a/scripts/iou-start.sh
+++ b/scripts/iou-start.sh
@@ -6,12 +6,12 @@ xbridge-cli explorer
 jq .LockingChain.DoorAccount.Address $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
 jq '.LockingChain.WitnessSubmitAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
 jq '.LockingChain.WitnessRewardAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
-xbridge-cli bridge build --name=bridge -v
+xbridge-cli bridge build --name=bridge
 xbridge-cli server start-all --witness-only
 xbridge-cli server list
 xbridge-cli fund locking_chain raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
-xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10 -v
-xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose
+xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10
+xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM
 
 echo "set up IOU bridge"
 xbridge-cli fund locking_chain raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
@@ -20,9 +20,9 @@ xbridge-cli server create-config all --config_dir ../xbridge-config2 --currency 
 jq .LockingChain.DoorAccount.Address ../xbridge-config2/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
 jq '.LockingChain.WitnessSubmitAccounts[]' ../xbridge-config2/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
 jq '.LockingChain.WitnessRewardAccounts[]' ../xbridge-config2/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
-jq .IssuingChain.DoorAccount.Address ../xbridge-config2/bridge_bootstrap.json | tr -d '"' | xargs -L1 xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --amount 50 -v --to
-jq '.IssuingChain.WitnessSubmitAccounts[]' ../xbridge-config2/bridge_bootstrap.json | tr -d '"' | xargs -L1 xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --amount 50 -v --to
-jq '.IssuingChain.WitnessRewardAccounts[]' ../xbridge-config2/bridge_bootstrap.json | tr -d '"' | xargs -L1 xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --amount 50 -v --to
+jq .IssuingChain.DoorAccount.Address ../xbridge-config2/bridge_bootstrap.json | tr -d '"' | xargs -L1 xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --amount 50 --to
+jq '.IssuingChain.WitnessSubmitAccounts[]' ../xbridge-config2/bridge_bootstrap.json | tr -d '"' | xargs -L1 xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --amount 50 --to
+jq '.IssuingChain.WitnessRewardAccounts[]' ../xbridge-config2/bridge_bootstrap.json | tr -d '"' | xargs -L1 xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --amount 50 --to
 xbridge-cli server stop --name witness0
 xbridge-cli server stop --name witness1
 xbridge-cli server stop --name witness2
@@ -31,7 +31,7 @@ xbridge-cli server stop --name witness4
 xbridge-cli server list
 xbridge-cli server start-all --witness-only --config_dir ../xbridge-config2
 xbridge-cli server list
-xbridge-cli bridge build --name iou_bridge --bootstrap ../xbridge-config2/bridge_bootstrap.json -v
+xbridge-cli bridge build --name iou_bridge --bootstrap ../xbridge-config2/bridge_bootstrap.json
 jq .LockingChain.DoorAccount.Seed ../xbridge-config2/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli trust locking_chain USD.raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
 jq .IssuingChain.DoorAccount.Address ../xbridge-config2/bridge_bootstrap.json | tr -d '"' | xargs -I{} xbridge-cli trust issuing_chain USD.{} snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM
-xbridge-cli bridge transfer --bridge iou_bridge --from_locking --amount 1000 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose
+xbridge-cli bridge transfer --bridge iou_bridge --from_locking --amount 1000 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -6,7 +6,7 @@ xbridge-cli explorer
 jq .LockingChain.DoorAccount.Address $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
 jq '.LockingChain.WitnessSubmitAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
 jq '.LockingChain.WitnessRewardAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
-xbridge-cli bridge build --name=bridge -v
+xbridge-cli bridge build --name=bridge
 xbridge-cli fund locking_chain raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
-xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10 -v
-xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose
+xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10
+xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM

--- a/scripts/tutorial.sh
+++ b/scripts/tutorial.sh
@@ -7,7 +7,7 @@ xbridge-cli explorer
 jq .LockingChain.DoorAccount.Address $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
 jq '.LockingChain.WitnessSubmitAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
 jq '.LockingChain.WitnessRewardAccounts[]' $XCHAIN_CONFIG_DIR/bridge_bootstrap.json | tr -d '"' | xargs xbridge-cli fund locking_chain
-xbridge-cli bridge build --name=bridge -v
+xbridge-cli bridge build --name=bridge
 xbridge-cli fund locking_chain raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
-xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10 -v
+xbridge-cli bridge create-account --from_locking --bridge bridge --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi --amount 10
 xbridge-cli bridge transfer --bridge bridge --from_locking --amount 10 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --tutorial

--- a/xbridge_cli/bridge/build.py
+++ b/xbridge_cli/bridge/build.py
@@ -129,7 +129,7 @@ def setup_bridge(
             be closed; an external network does not support ledger closing.
         verbose: Whether or not to print more verbose information. Add more v's for
             more verbosity.
-        silent: Whether or not to print no information. Cannot be used with -v.
+        silent: Whether or not to print no information. Cannot be used with `-v`.
 
     Raises:
         XBridgeCLIException: If an account on the locking chain doesn't exist

--- a/xbridge_cli/bridge/transfer.py
+++ b/xbridge_cli/bridge/transfer.py
@@ -106,6 +106,12 @@ def _submit_tx(
     help="Whether or not to print more verbose information. Supports `-vv`.",
 )
 @click.option(
+    "-s",
+    "--silent",
+    is_flag=True,
+    help="Whether or not to print no information. Cannot be used with -v.",
+)
+@click.option(
     "--tutorial",
     is_flag=True,
     help="Turn this flag on if you want to slow down and really understand each step.",
@@ -118,6 +124,7 @@ def send_transfer(
     to_account: str,
     close_ledgers: bool = True,
     verbose: int = 0,
+    silent: bool = False,
     tutorial: bool = False,
 ) -> None:
     """
@@ -135,6 +142,7 @@ def send_transfer(
             for ledgers to close automatically. A standalone node requires ledgers to
             be closed; an external network does not support ledger closing.
         verbose: Whether or not to print more verbose information. Supports `-vv`.
+        silent: Whether or not to print no information. Cannot be used with `-v`.
         tutorial: Whether to slow down and explain each step.
 
     Raises:
@@ -143,7 +151,13 @@ def send_transfer(
         AttestationTimeoutException: If there is a timeout when waiting for
             attestations.
     """  # noqa: D301
-    print_level = max(verbose, 2 if tutorial else 0)
+    if silent and verbose > 0:
+        raise XBridgeCLIException("Cannot have verbose and silent flags.")
+    if silent and tutorial:
+        raise XBridgeCLIException("Cannot have tutorial and silent flags.")
+
+    verbosity = 0 if silent else 1 + verbose
+    print_level = max(verbosity, 2 if tutorial else 0)
     bridge_config = get_config().get_bridge(bridge)
     bridge_obj = bridge_config.get_bridge()
     locking_client, issuing_client = bridge_config.get_clients()

--- a/xbridge_cli/bridge/transfer.py
+++ b/xbridge_cli/bridge/transfer.py
@@ -26,10 +26,10 @@ def _submit_tx(
     tx: Transaction,
     client: JsonRpcClient,
     wallet: Wallet,
-    verbose: int,
+    verbosity: int,
     close_ledgers: bool,
 ) -> Response:
-    result = submit_tx(tx, client, wallet, verbose, close_ledgers)[0]
+    result = submit_tx(tx, client, wallet, verbosity, close_ledgers)[0]
     tx_result = (
         result.result.get("error")
         or result.result.get("engine_result")
@@ -263,5 +263,5 @@ def send_transfer(
         transfer_amount,
         xchain_claim_id,
         close_ledgers,
-        verbose,
+        verbosity,
     )


### PR DESCRIPTION
## High Level Overview of Change

This PR adjusts the default verbosity for `xbridge-cli bridge build`, `xbridge-cli bridge transfer`, and `xbridge-cli bridge create-account` to match what was previously outputted with `-v`, and adds a ` --silent` flag to represent outputting nothing.

### Context of Change

Requested by @sgramkumar - it makes it easier for first-time users to figure out what's going on with each command.

### Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Plan

Works locally.
