### PR TITLE
fix: better error handling for `account_objects` failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 
+### Fixed
+
+- Better error handling for the `account_objects` call in `bridge create`
+
 ## [0.3.0] - 2023-04-17
 
 ### Added
@@ -30,11 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated to match the latest versions of rippled and the witness server
+- Update to match the latest versions of rippled and the witness server
 
 ### Fixed
 
-- Fixed a key algorithm-seed type mismatch for IOU bridge config generation
+- Fix a key algorithm-seed type mismatch for IOU bridge config generation
 
 ## [0.1.0] - 2023-02-22
 

--- a/xbridge_cli/bridge/build.py
+++ b/xbridge_cli/bridge/build.py
@@ -321,9 +321,15 @@ def setup_bridge(
 
     # check if the bridge already exists
     locking_bridge_exists = False
-    locking_door_objs = locking_client.request(
+    locking_objs_result = locking_client.request(
         AccountObjects(account=locking_door, type=AccountObjectType.BRIDGE)
-    ).result["account_objects"]
+    ).result
+    if "account_objects" not in locking_objs_result:
+        obj_error = locking_objs_result.get("error_message") or json.dumps(
+            locking_objs_result
+        )
+        raise XBridgeCLIException(obj_error)
+    locking_door_objs = locking_objs_result["account_objects"]
     if len(locking_door_objs) > 0:
         assert (
             len(locking_door_objs) == 1
@@ -437,9 +443,15 @@ def setup_bridge(
 
     # check if the bridge already exists
     issuing_bridge_exists = False
-    issuing_door_objs = issuing_client.request(
+    issuing_objs_result = issuing_client.request(
         AccountObjects(account=issuing_door, type=AccountObjectType.BRIDGE)
-    ).result["account_objects"]
+    ).result
+    if "account_objects" not in issuing_objs_result:
+        obj_error = issuing_objs_result.get("error_message") or json.dumps(
+            issuing_objs_result
+        )
+        raise XBridgeCLIException(obj_error)
+    issuing_door_objs = issuing_objs_result["account_objects"]
     if len(issuing_door_objs) > 0:
         assert (
             len(issuing_door_objs) == 1


### PR DESCRIPTION
## High Level Overview of Change

The `account_objects` call in the `bridge create` method can fail, especially when accidentally run on networks that don't have `XChainBridge` enabled. This PR makes that a bit cleaner, so the error is easier to read.

### Context of Change

Some folks have run into this issue.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

CI passes locally.
