### PR TITLE
chore: update beta, update version to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[Unreleased]]
 
+## [0.3.2] - 2023-09-25
+
+### Fixed
+
+- Updated xrpl-py beta version to add support for Network ID feature
+
+## [0.3.1] - 2023-07-12
+
 ### Fixed
 
 - Better error handling for the `account_objects` call in `bridge create`

--- a/poetry.lock
+++ b/poetry.lock
@@ -313,20 +313,20 @@ files = [
 
 [[package]]
 name = "deprecated"
-version = "1.2.13"
+version = "1.2.14"
 description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
-    {file = "Deprecated-1.2.13-py2.py3-none-any.whl", hash = "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"},
-    {file = "Deprecated-1.2.13.tar.gz", hash = "sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d"},
+    {file = "Deprecated-1.2.14-py2.py3-none-any.whl", hash = "sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c"},
+    {file = "Deprecated-1.2.14.tar.gz", hash = "sha256:e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3"},
 ]
 
 [package.dependencies]
 wrapt = ">=1.10,<2"
 
 [package.extras]
-dev = ["PyTest", "PyTest (<5)", "PyTest-Cov", "PyTest-Cov (<2.6)", "bump2version (<1)", "configparser (<5)", "importlib-metadata (<3)", "importlib-resources (<4)", "sphinx (<2)", "sphinxcontrib-websupport (<2)", "tox", "zipp (<2)"]
+dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "sphinx (<2)", "tox"]
 
 [[package]]
 name = "docker"
@@ -1066,13 +1066,13 @@ files = [
 
 [[package]]
 name = "types-deprecated"
-version = "1.2.9.2"
+version = "1.2.9.3"
 description = "Typing stubs for Deprecated"
 optional = false
 python-versions = "*"
 files = [
-    {file = "types-Deprecated-1.2.9.2.tar.gz", hash = "sha256:91616fd6745f8bf2d457fbbbefd14cde43838e9f00a04b5a0eae4fc1f7bbc697"},
-    {file = "types_Deprecated-1.2.9.2-py3-none-any.whl", hash = "sha256:327783e137353b0ef9cf47a8cd4b1c0b8ae72f6554eb25820783c6a81a3d556f"},
+    {file = "types-Deprecated-1.2.9.3.tar.gz", hash = "sha256:ef87327adf3e3c4a4c7d8e06e58f6476710d3466ecfb53c49efb080804a70ef3"},
+    {file = "types_Deprecated-1.2.9.3-py3-none-any.whl", hash = "sha256:24da9210763e5e1b3d0d4f6f8bba9ad3bb6af3fe7f6815fc37e3ede4681704f5"},
 ]
 
 [[package]]
@@ -1293,13 +1293,13 @@ files = [
 
 [[package]]
 name = "xrpl-py"
-version = "2.1.0b0"
+version = "2.4.0b0"
 description = "A complete Python library for interacting with the XRP ledger"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "xrpl_py-2.1.0b0-py3-none-any.whl", hash = "sha256:e3c680d02401f49081da55eac24972ada4e252b5b9e50645d43a6a2091a36c31"},
-    {file = "xrpl_py-2.1.0b0.tar.gz", hash = "sha256:1b91b0e4ad67caacc996b6b4fcadde0b767996d40aff597c70785221c4661ed5"},
+    {file = "xrpl_py-2.4.0b0-py3-none-any.whl", hash = "sha256:54c3d3d2824ac57fbae6e63b30bd3558412b026c087bfd1ca1b7f404f0de0b5c"},
+    {file = "xrpl_py-2.4.0b0.tar.gz", hash = "sha256:d6a81165e61da0cbe1e7eb30494a32c3ed02b2771808c0cc15fcbcdf397bdb65"},
 ]
 
 [package.dependencies]
@@ -1333,4 +1333,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7.1"
-content-hash = "2f1d130701b2ba788442f84864281c7d8b20b6d8f210188fff5814c0445fc256"
+content-hash = "0394b1486527c2fd439d679fc807fca8caaea302f19e1a21d3491040e8822037"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ websockets = "^10.3"
 Jinja2 = "^3.1.2"
 psutil = "^5.9.2"
 docker = "^6.0.0"
-xrpl-py = "2.1.0b0"
+xrpl-py = "2.4.0b0"
 pycryptodome = "^3.17"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xbridge-cli"
-version = "0.3.1"
+version = "0.3.2"
 description = "A CLI that helps you set up an XRPL-XRPL bridge."
 readme = "README.md"
 repository = "https://github.com/xpring-eng/xbridge-cli"


### PR DESCRIPTION
## High Level Overview of Change

This PR updates the xrpl-py beta to the latest version, and bumps the xbridge-cli version to 0.3.2.

### Context of Change

Network ID features are needed.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Release

## Test Plan

CI probably passes. Can't test right now.
